### PR TITLE
Fixed typo in Include conf.d statement

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ collectd_prefix: /opt/collectd      # The place where Collectd will be installed
 collectd_prefix_type: "{{collectd_prefix}}/etc"
 collectd_prefix_conf: "{{collectd_prefix}}/etc"
 collectd_prefix_sbin: "{{collectd_prefix}}/sbin"
+collectd_plugins_prefix: "{{collectd_prefix_conf}}/conf.d"
 
 # General options
 collectd_interval: 10

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,6 +4,9 @@
   template: src=collectd.conf.j2 dest={{collectd_prefix_conf}}/collectd.conf validate='{{collectd_prefix_sbin}}/collectd -t -C %s'
   notify: collectd restart
 
+- name: collectd-configure | Ensure conf.d directory
+  file: path={{collectd_plugins_prefix}} state=directory
+
 - name: collectd-configure | Configure types
   template: src=types.db.j2 dest={{collectd_prefix_type}}/types.db
   notify: collectd restart

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -62,6 +62,6 @@ LoadPlugin write_graphite
 </Plugin>
 {% endif %}
 
-<Include "{{collectd_prefix_conf}}/collectd.conf.d">
+<Include "{{collectd_plugins_prefix}}">
         Filter "*.conf"
 </Include>


### PR DESCRIPTION
Collectd were including quite strange, non-default conf.d directory
"/opt/collectd/etc/collectd.conf.d".
I assume that it were typo, because default for that configuration
is "/opt/collectd/etc/conf.d". Fixed template to contain the
default path and ensure that directory exists.
