### PR TITLE
Support Collectd 5.5 and above

### DIFF
--- a/templates/upstart.conf.j2
+++ b/templates/upstart.conf.j2
@@ -8,7 +8,11 @@ stop on runlevel [!2345]
 env DAEMON={{collectd_prefix_sbin}}/collectd
 
 # Tell upstart to watch for forking when tracking the pid for us.
+{% if collectd_version | version_compare('5.5.0', '>=') %}
+expect stop
+{% else %}
 expect fork
+{% endif %}
 
 # prevent thrashing - 10 restarts in 5 seconds
 respawn


### PR DESCRIPTION
Hi,

After configuring with `collectd_version: 5.5.0`, upstart was not able to restart (it just hangs indefinitely).
It seems related to a change in Collectd.

Related commit: https://github.com/collectd/collectd/commit/ff270e6d53374bddca9f3fe0bb7a8c2294548edc

```
This allows collectd to be either configured with `expect stop` [...]
```
