### PR TITLE
Install libyajl-dev (required to curl_json plugin)

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -2,7 +2,7 @@
 
 - name: collectd-install | Install dependencies
   apt: name={{item}}
-  with_items: [build-essential, libcurl4-openssl-dev, libpcap-dev, librrd-dev]
+  with_items: [build-essential, libcurl4-openssl-dev, libpcap-dev, librrd-dev, libyajl-dev]
 
 - name: collectd-install | Download Collectd
   get_url: url=http://collectd.org/files/collectd-{{collectd_version}}.tar.gz dest=/usr/src


### PR DESCRIPTION
Hello, Kirill.

I added libyajl-dev to the list of debian packages to install. With this package collectd compiles with curl_json plugin.

Thanks for the role.
