### PR TITLE
* allow to disable detection of collectd_service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 collectd_enabled: yes               # Enable the role
 collectd_version: 5.5.2             # Set version
 collectd_service: upstart
+collectd_service_autodetect: true   # try to detect collectd_service
 
 # PPA options
 collectd_use_ppa: no                # Use the collectd PPA

--- a/tasks/collectd.yml
+++ b/tasks/collectd.yml
@@ -7,7 +7,7 @@
   with_first_found:
   - "{{ ansible_os_family }}-{{ ansible_lsb.codename }}.yml"
   - "Debian-default.yml"
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and collectd_service_autodetect
 
 - include: install.ppa.yml
   when: collectd_use_ppa


### PR DESCRIPTION
Currently it's not possible to override value of collectd_service if the target OS is debian. For example for 16.04 it's always = systemd, event if the variable is defined in the playbook.