### PR TITLE
redhat based systems enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,35 @@
 Stouts.collectd
 ==========
 
+#installation from package on centos with write_graphite package enabled
+- hosts: xeon_01
+  roles:
+    - role: collectd
+      collectd_plugins: [write_graphite]
+      collectd_plugins_options:
+        write_graphite:
+          Host: x.x.x.x
+
+
+#installation from sources on centos with with logging to file enabled
+- hosts: xeon_02
+  roles:
+    - role: collectd
+      collectd_method: src
+      collectd_version: "5.8.0"
+      collectd_logpath: /var/log/collectd.log
+      collectd_interval: 5
+
+#installation from package on arm/ubuntu (automatic)
+ - hosts: taishan-2180-01
+   roles: 
+     - role: collectd 
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!DEPRECATED!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 [![Build Status](http://img.shields.io/travis/Stouts/Stouts.collectd.svg?style=flat-square)](https://travis-ci.org/Stouts/Stouts.collectd)
 [![Galaxy](http://img.shields.io/badge/galaxy-Stouts.collectd-blue.svg?style=flat-square)](https://galaxy.ansible.com/list#/roles/1960)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,13 +2,13 @@
 
 collectd_enabled: yes               # Enable the role
 collectd_version: 5.5.2             # Set version
-collectd_service: upstart
-collectd_service_autodetect: true   # try to detect collectd_service
+#collectd_service: upstart
+#collectd_service_autodetect: true   # try to detect collectd_service
 
 # PPA options
-collectd_use_ppa: no                # Use the collectd PPA
-collectd_use_ppa_latest: no         # Don't fix package version to collectd_version
-collectd_ppa_source: 'ppa:collectd/collectd-5.5'
+collectd_method: pkg                # method to install collectd (yum, ppa, or src, or pkg)
+collectd_use_pkg_latest: yes         # Don't fix package version to collectd_version
+collectd_ppa_source: #'ppa:collectd/collectd-5.5'
 
 # Source options
 collectd_prefix: /opt/collectd      # The place where Collectd will be installed
@@ -20,7 +20,7 @@ collectd_plugins_prefix: "{{collectd_prefix_conf}}/conf.d"
 # General options
 collectd_interval: 10
 collectd_readthreads: 7
-collectd_hostname: "{{ inventory_hostname }}"
+collectd_hostname: #"{{ inventory_hostname }}"
 collectd_fdqnlookup: false
 
 # Collectd plugins
@@ -28,30 +28,27 @@ collectd_plugins: []                # Ex. [nginx, memcached]
 collectd_plugins_options: {}        # See below for examples.
 
 # Collectd default plugins
-collectd_default_plugins: [cpu, df, interface, load, memory, swap]
+collectd_default_plugins: [cpu, df, interface, load, memory, swap, disk]
 collectd_default_plugins_options:
   swap:
-  - ReportByDevice false
+    ReportByDevice: false
   interface:
-  - Interface lo
-  - IgnoreSelected true
+    Interface: lo
+    IgnoreSelected: true
+  write_graphite:
+    Host: "{{inventory_hostname}}"
+    Port: 2003
+    Prefix: ""
+    # Postfix: .collectd
+    Protocol: tcp
+    AlwaysAppendDS: 'false'
+    EscapeCharacter: _
+    LogSendErrors: 'true'
+    StoreRates: 'true'
 
 # Additional types
 # format: { name: ..., value: ... }
 collectd_types: []
-
-# Collectd graphite options
-collectd_write_graphite: no
-collectd_write_graphite_options:    # Setup write_graphite (https://collectd.org/wiki/index.php/Plugin:Write_Graphite)
-  Host: "{{inventory_hostname}}"
-  Port: 2003
-  Prefix: stats.
-  # Postfix: .collectd
-  Protocol: tcp
-  AlwaysAppendDS: 'false'
-  EscapeCharacter: _
-  LogSendErrors: 'true'
-  StoreRates: 'true'
 
 # Setup logs
 collectd_logpath:                   # If it is not empty, will be used logfile
@@ -67,9 +64,11 @@ collectd_logrotate_options:
   - size 10M
 
 # Paths
-collectd_types_db_path: "{{ '/usr/share/collectd/types.db' if collectd_use_ppa else collectd_prefix + '/share/collectd/types.db' }}"
-collectd_additional_types_db_path: "{{ '/usr/share/collectd/additional-types.db' if collectd_use_ppa else collectd_prefix_type + '/types.db' }}"
-collectd_config_file: "{{ '/etc/collectd/collectd.conf' if collectd_use_ppa else collectd_prefix_conf + '/collectd.conf' }}"
-collectd_config_dir: "{{ '/etc/collectd/collectd.conf.d' if collectd_use_ppa else collectd_plugins_prefix }}"
-collectd_plugins_dir: "{{ '/usr/lib/collectd' if collectd_use_ppa else collectd_prefix + '/lib/collectd' }}"
-collectd_sbin_path: "{{ '/usr/sbin' if collectd_use_ppa else collectd_prefix_sbin }}"
+collectd_types_db_path: "{{ '/usr/share/collectd/types.db' if collectd_method != 'src' else collectd_prefix + '/share/collectd/types.db' }}"
+collectd_additional_types_db_path: "{{ '/usr/share/collectd/additional-types.db' if collectd_method != 'src' else collectd_prefix_type + '/types.db' }}"
+collectd_sbin_path: "{{ '/usr/sbin' if collectd_method != 'src' else collectd_prefix_sbin }}"
+
+#set by filesystem defaults
+collectd_config_file:
+collectd_config_dir:
+collectd_plugins_dir:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 
 - name: collectd restart
   service: name=collectd state=restarted
+  become: True

--- a/tasks/collectd.yml
+++ b/tasks/collectd.yml
@@ -1,25 +1,38 @@
 ---
 
-- debug: var=ansible_os_family
-
 - name: Include OS-specific variables.
   include_vars: "{{item}}"
   with_first_found:
   - "{{ ansible_os_family }}-{{ ansible_lsb.codename }}.yml"
-  - "Debian-default.yml"
-  when: ansible_os_family == 'Debian' and collectd_service_autodetect
+  - "{{ ansible_os_family }}.yml"
 
 - import_tasks: install.ppa.yml
-  when: collectd_use_ppa
+  when: collectd_method_deduced == 'ppa'
+  become: True
+  tags: [collectd, collectd-install]
+
+- import_tasks: install.yum.yml
+  when: collectd_method_deduced == 'yum'
+  become: True
   tags: [collectd, collectd-install]
 
 - import_tasks: install.deb.yml
-  when: not collectd_use_ppa and ansible_os_family == 'Debian'
+  when: collectd_method_deduced == 'src' 
+  become: True
   tags: [collectd, collectd-install]
 
+
+- name: merge plugins
+  set_fact:
+    collectd_plugins_combined: "{{ collectd_default_plugins | union(collectd_plugins) | unique }}"
+    collectd_plugins_options_combined: "{{ collectd_default_plugins_options | combine(collectd_plugins_options, recursive=True) }}"
+  tags: [collectd, collectd-configure]
+
 - import_tasks: configure.yml
+  become: True
   tags: [collectd, collectd-configure]
 
 - import_tasks: configure-service.yml
-  when: not collectd_use_ppa
+  when: collectd_method_deduced == 'src'
+  become: True
   tags: [collectd, collectd-configure]

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,11 +1,14 @@
 ---
 
+- debug: 
+    var: collectd_config_file_deduced
+
 - name: collectd-configure | Configure Collectd
-  template: src=collectd.conf.j2 dest={{collectd_config_file}} validate='{{collectd_sbin_path}}/collectd -t -C %s'
+  template: src=collectd.conf.j2 dest={{collectd_config_file_deduced}} validate='{{collectd_sbin_path}}/collectd -t -C %s'
   notify: collectd restart
 
 - name: collectd-configure | Ensure conf.d directory
-  file: path={{collectd_config_dir}} state=directory
+  file: path={{collectd_config_dir_deduced}} state=directory
 
 - name: collectd-configure | Configure additional types
   template: src=types.db.j2 dest={{collectd_additional_types_db_path}}

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,15 +1,20 @@
 ---
 
+#TODO, to change 
+#- name: fail, to change
+#  fail:
+#    msg:  TODO test manual installation
+
 - name: collectd-install | Install dependencies
-  apt: name={{item}} force=yes
-  with_items: [build-essential, libcurl4-openssl-dev, libpcap-dev, libyajl-dev]
+  package: name={{item}} state=present
+  with_items: "{{ collectd_source_packages }}"
 
 - name: collectd-install | Download Collectd
-  get_url: url=http://collectd.org/files/collectd-{{collectd_version}}.tar.gz dest=/usr/src
+  get_url: url=http://collectd.org/files/collectd-{{collectd_version}}.tar.bz2 dest=/usr/src
   register: collectd_source
 
 - name: collectd-install | Extract Collectd
-  unarchive: src=/usr/src/collectd-{{collectd_version}}.tar.gz dest=/usr/src copy=no
+  unarchive: src=/usr/src/collectd-{{collectd_version}}.tar.bz2 dest=/usr/src copy=no
   when: collectd_source.changed
 
 - name: collectd-install | Install Collectd

--- a/tasks/install.ppa.yml
+++ b/tasks/install.ppa.yml
@@ -1,15 +1,16 @@
 ---
 
-- name: collectd-install | Install ppa
+- name: collectd-install | Install ppa (Debian)
   apt_repository: >
     repo={{ collectd_ppa_source }}
     update_cache=yes
+  when: collectd_ppa_source
 
-- name: collectd-install | Install specific collectd package
+- name: collectd-install | Install specific collectd package (Debian)
   apt: >
     name=collectd={{ collectd_version }}
-  when: not collectd_use_ppa_latest
+  when: not collectd_use_pkg_latest
 
-- name: collectd-install | Install latest collectd package
+- name: collectd-install | Install latest collectd package (Debian)
   apt: name=collectd
-  when: collectd_use_ppa_latest
+  when: collectd_use_pkg_latest

--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -1,0 +1,13 @@
+---
+
+- name: collectd-install | Install specific collectd package (RedHat)
+  yum: 
+    name: collectd-{{ collectd_version }}
+    update_cache: True
+  when: not collectd_use_pkg_latest
+
+- name: collectd-install | Install latest collectd package (RedHat)
+  yum: 
+    name: collectd
+    update_cache: True
+  when: collectd_use_pkg_latest

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -26,41 +26,27 @@ LoadPlugin syslog
 </Plugin>
 {% endif %}
 
-# Default plugins
-{% for plugin in collectd_default_plugins %}
+# Plugins
+{% for plugin in collectd_plugins_combined %}
 LoadPlugin {{ plugin }}
-{% if collectd_default_plugins_options.get(plugin) %}
+{% if collectd_plugins_options_combined.get(plugin) %}
 <Plugin {{plugin}}>
-{% for line in collectd_default_plugins_options[plugin] %}
-	{{line}}
+{% if plugin == 'write_graphite' %}
+ <Node "1">
+{% endif %}
+{% for name, value in collectd_plugins_options_combined[plugin].items() %}
+{% if value | lower in ['true', 'false'] %}
+	{{name}} {{value}}
+{% else %}
+	{{name}} "{{value}}"
+{% endif %}
 {% endfor %}
+{% if plugin == 'write_graphite' %}
+ </Node>
+{% endif %}
 </Plugin>
 {% endif %}
 {% endfor %}
-
-# User plugins
-{% for plugin in collectd_plugins %}
-LoadPlugin {{ plugin }}
-{% if collectd_plugins_options.get(plugin) %}
-<Plugin {{plugin}}>
-{% for line in collectd_plugins_options[plugin] %}
-	{{line}}
-{% endfor %}
-</Plugin>
-{% endif %}
-{% endfor %}
-
-{% if collectd_write_graphite %}
-# Carbon
-LoadPlugin write_graphite
-<Plugin write_graphite>
-  <Node "{{inventory_hostname}}">
-{% for name, value in collectd_write_graphite_options.items() %}
-    {{ name }} "{{ value }}"
-{% endfor %}
-  </Node>
-</Plugin>
-{% endif %}
 
 <Include "{{collectd_config_dir}}">
         Filter "*.conf"

--- a/vars/Debian-default.yml
+++ b/vars/Debian-default.yml
@@ -1,3 +1,0 @@
----
-
-collectd_service: upstart

--- a/vars/Debian-vivid.yml
+++ b/vars/Debian-vivid.yml
@@ -1,4 +1,9 @@
 ---
 
 collectd_service: systemd
+collectd_method_deduced: "{{ collectd_method if collectd_method !='pkg' else 'ppa' }}"
 
+collectd_config_file_deduced: "{{ collectd_config_file if collectd_config_file else '/etc/collectd/collectd.conf' if collectd_method_deduced == 'ppa' else collectd_prefix_conf + '/collectd.conf' }}"
+collectd_config_dir_deduced:  "{{ collectd_config_dir  if collectd_config_dir  else '/etc/collectd/collectd.conf.d' if collectd_method_deduced == 'ppa' else collectd_plugins_prefix }}"
+collectd_plugins_dir_deduced: "{{ collectd_plugins_dir if collectd_plugins_dir else '/usr/lib/collectd' if collectd_method_deduced == 'ppa' else collectd_prefix + '/lib/collectd' }}"
+collectd_source_packages: [build-essential, libcurl4-openssl-dev, libpcap-dev, libyajl-dev]

--- a/vars/Debian-xenial.yml
+++ b/vars/Debian-xenial.yml
@@ -1,4 +1,9 @@
 ---
 
 collectd_service: systemd
+collectd_method_deduced: "{{ collectd_method if collectd_method !='pkg' else 'ppa' }}"
 
+collectd_config_file_deduced: "{{ collectd_config_file if collectd_config_file else '/etc/collectd/collectd.conf' if collectd_method_deduced == 'ppa' else collectd_prefix_conf + '/collectd.conf' }}"
+collectd_config_dir_deduced:  "{{ collectd_config_dir  if collectd_config_dir  else '/etc/collectd/collectd.conf.d' if collectd_method_deduced == 'ppa' else collectd_plugins_prefix }}"
+collectd_plugins_dir_deduced: "{{ collectd_plugins_dir if collectd_plugins_dir else '/usr/lib/collectd' if collectd_method_deduced == 'ppa' else collectd_prefix + '/lib/collectd' }}"
+collectd_source_packages: [build-essential, libcurl4-openssl-dev, libpcap-dev, libyajl-dev]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,10 @@
 ---
 
-collectd_service: systemd
+collectd_service: upstart
 collectd_method_deduced: "{{ collectd_method if collectd_method !='pkg' else 'ppa' }}"
 
 collectd_config_file_deduced: "{{ collectd_config_file if collectd_config_file else '/etc/collectd/collectd.conf' if collectd_method_deduced == 'ppa' else collectd_prefix_conf + '/collectd.conf' }}"
 collectd_config_dir_deduced:  "{{ collectd_config_dir  if collectd_config_dir  else '/etc/collectd/collectd.conf.d' if collectd_method_deduced == 'ppa' else collectd_plugins_prefix }}"
 collectd_plugins_dir_deduced: "{{ collectd_plugins_dir if collectd_plugins_dir else '/usr/lib/collectd' if collectd_method_deduced == 'ppa' else collectd_prefix + '/lib/collectd' }}"
+
 collectd_source_packages: [build-essential, libcurl4-openssl-dev, libpcap-dev, libyajl-dev]

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,10 @@
+---
+
+collectd_service: systemd
+collectd_method_deduced: "{{ collectd_method if collectd_method !='pkg' else 'yum' }}"
+
+collectd_config_file_deduced: "{{ collectd_config_file if collectd_config_file else '/etc/collectd.conf' if collectd_method_deduced == 'yum' else collectd_prefix_conf + '/collectd.conf' }}"
+collectd_config_dir_deduced:  "{{ collectd_config_dir  if collectd_config_dir  else '/etc/collectd.d' if collectd_method_deduced == 'yum' else collectd_plugins_prefix }}"
+collectd_plugins_dir_deduced: "{{ collectd_plugins_dir if collectd_plugins_dir else '/usr/lib64/collectd' if collectd_method_deduced == 'yum' else collectd_prefix + '/lib/collectd' }}"
+
+collectd_source_packages: [make, automake, gcc, gcc-c++, kernel-devel, libcap-devel, libcurl-devel, openssl-devel, yajl-devel]


### PR DESCRIPTION
new collectd_method variable which can be: pkg, src, yum, ppa
pkg, automatically installs either redha or debian package

changed some defaults variables (default latest from repository,
external repository)

simplified the plugin usage (for instance write_graphite now is just
another plugin); The plugins defaults values and default plugins are now
merged into one list, and there is no chance for duplication

Documentation is not updated. Some cleaning would be good.

Designed for centos/redhat >=7 (will not work on older), because of
systemd introduced in redhat 7.

Tested for centos 7 and ubuntu 16.04.