### PR TITLE
Add collectd_config_file_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,6 @@ collectd_config_file: "{{ '/etc/collectd/collectd.conf' if collectd_use_ppa else
 collectd_config_dir: "{{ '/etc/collectd/collectd.conf.d' if collectd_use_ppa else collectd_plugins_prefix }}"
 collectd_plugins_dir: "{{ '/usr/lib/collectd' if collectd_use_ppa else collectd_prefix + '/lib/collectd' }}"
 collectd_sbin_path: "{{ '/usr/sbin' if collectd_use_ppa else collectd_prefix_sbin }}"
+
+# Collectd configuration file permissions
+collectd_config_file_mode: '0644'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: collectd-configure | Configure Collectd
-  template: src=collectd.conf.j2 dest={{collectd_config_file}} validate='{{collectd_sbin_path}}/collectd -t -C %s'
+  template: src=collectd.conf.j2 mode={{collectd_config_file_mode}} dest={{collectd_config_file}} validate='{{collectd_sbin_path}}/collectd -t -C %s'
   notify: collectd restart
 
 - name: collectd-configure | Ensure conf.d directory


### PR DESCRIPTION
As for some Collectd pluguins can introduce secrets in the configuration file (like the `mysql` pluguin), it would be nice to be able to restrict the configuration file permissions.

I added the `collectd_config_file_mode` variable with default value equal to systems default in most systems.